### PR TITLE
Remove year 2022 for selenium and testcafe

### DIFF
--- a/surveyform/src/surveys/stateofjs/js2022.yml
+++ b/surveyform/src/surveys/stateofjs/js2022.yml
@@ -320,9 +320,7 @@ outline:
       - id: vitest
         year: 2021
       - id: selenium
-        year: 2022
       - id: testcafe
-        year: 2022
       - id: testing
         intlId: tools.other_tools
         template: project


### PR DESCRIPTION
Hello,

Is it normal that selenium and testcafe have the "2022" tag?

It seems to be a mistake so I suggest to remove it. If not, please close my PR.

Thanks

![Screenshot_20221129-212217_Kiwi Browser](https://user-images.githubusercontent.com/2855723/204642611-45f75499-cd66-4742-be0c-cef971553a4a.jpg)
