### PR TITLE
fix: survey crash on unauthenticed user

### DIFF
--- a/surveyform/src/core/components/survey/questions/SurveySection.tsx
+++ b/surveyform/src/core/components/survey/questions/SurveySection.tsx
@@ -6,6 +6,8 @@ import { useSurveyResponseParams } from "../hooks";
 import surveys from "~/surveys";
 import { EntitiesProvider } from "~/core/components/common/EntitiesContext";
 import { getEntityIdsFromSurvey } from "~/modules/entities/helpers";
+import { useUser } from "~/account/user/hooks";
+import { useRouter } from "next/router";
 
 const SurveySection = () => {
   let {
@@ -15,6 +17,9 @@ const SurveySection = () => {
     year,
     paramsReady,
   } = useSurveyResponseParams();
+  const { user, loading: userLoading } = useUser();
+  const router = useRouter();
+
   // TODO: use a "SurveyContext" that is populated at layout level with the
   // current survey, and use "useCurrentSurvey"
   // This needs to wait for the incoming layout update of Next.js
@@ -22,11 +27,14 @@ const SurveySection = () => {
     (s) => s.prettySlug === slug && s.year === Number(year)
   );
 
-  if (!paramsReady) {
+  if (!paramsReady || userLoading) {
     return <div>Loading section…</div>;
   }
 
   if (!survey) throw new Error(`Survey with slug ${slug} not found`);
+  if (!user) {
+    router.replace("/account/login");
+  }
 
   const surveyOutline = survey.outline;
   const sectionIndex = sectionNumber - 1;


### PR DESCRIPTION
Hi 👋 

During testing I've discovered a very easily reproductible app crash in the `stateof*` family of surverys and I've decided to help out 😅

### Steps to reproduce

- Login on the page
- Start a new survey
- Copy survey URL (going back in the browser history also works)
- Log out
- Visit your previous survey URL 

### Video


https://user-images.githubusercontent.com/39658211/205077282-65c7556b-34fd-4b73-b24f-b3eec5842797.mov



### Proposed solution

Redirect user to login page when no `userId` found on .