### PR TITLE
Fix CreditItem Avatar stretching on mobile

### DIFF
--- a/results/src/core/blocks/other/CreditItem.js
+++ b/results/src/core/blocks/other/CreditItem.js
@@ -42,6 +42,7 @@ const CreditItemDiv = styled.div`
 
 const Avatar = styled.a`
     margin-right: ${spacing(0.5)};
+    flex-shrink: 0;
     overflow: hidden;
     border-radius: 100%;
     height: 60px;


### PR DESCRIPTION
Checking https://2022.stateofcss.com/en-US/conclusion/ on my phone I realized that Lea's avatar was being stretched.

The issue only appears if the role text is longer than 1 line.

Below screenshots with Chrome at 420px width:

**Before**

![image](https://user-images.githubusercontent.com/6631050/206121939-ed7659b8-76f7-403d-8e5e-a29f2ac72cb1.png)


**After**

![image](https://user-images.githubusercontent.com/6631050/206121814-8e2ed3a1-ce1b-4a30-8fc7-173bc8740078.png)