### PR TITLE
Fix typo in Kazakhstan country name

### DIFF
--- a/surveyform/src/modules/countries.ts
+++ b/surveyform/src/modules/countries.ts
@@ -111,7 +111,7 @@ const countries = [
   "Jamaica",
   "Japan",
   "Jordan",
-  "Kazakstan",
+  "Kazakhstan",
   "Kenya",
   "Kiribati",
   `Korea, Democratic People's Republic Of`,


### PR DESCRIPTION
Reference — https://en.wikipedia.org/wiki/Kazakhstan