### PR TITLE
Avoid overlapping lang menu with header cells of data explorer

### DIFF
--- a/results/src/core/blocks/explorer/Corner.tsx
+++ b/results/src/core/blocks/explorer/Corner.tsx
@@ -36,7 +36,7 @@ const Corner_ = styled.div`
 
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 9;
   backdrop-filter: blur(2px);
   .details-grid & {
     position: static;


### PR DESCRIPTION
This is a quick fix,  since still header cells overlap popovers.

![image](https://user-images.githubusercontent.com/4408379/206568805-af81744d-bd15-4ec9-9a57-e499b33eb2f0.png)

cc @SachaG 
