### PR TITLE
Fix: SVG course link

### DIFF
--- a/results/surveys/css2022/config/recommended_resources.yml
+++ b/results/surveys/css2022/config/recommended_resources.yml
@@ -93,7 +93,7 @@
   id: fm-svg
   description: |
     In this course, you'll learn to create immersive graphics and make them alive with animations!
-  url: ?utm_source=stateofcss&utm_medium=website&utm_campaign=stateofcss2022
+  url: https://frontendmasters.com/courses/svg-essentials-animation/?utm_source=stateofcss&utm_medium=website&utm_campaign=stateofcss2022
   image: https://static.frontendmasters.com/assets/teachers/drasner/thumb@2x.webp
   teacher: Sarah Drasner
   company: Netlify


### PR DESCRIPTION
## ✨ *Current behavior:*

The link of the course [SVG Essentials & Animation, v2](https://frontendmasters.com/courses/svg-essentials-animation/?utm_source=stateofcss&utm_medium=website&utm_campaign=stateofcss2021&utm_content=textlink) by Sarah Drasner is redirecting to the same page.

<img width="1422" alt="Captura de Pantalla 2022-12-12 a la(s) 5 28 04 p m" src="https://user-images.githubusercontent.com/25943655/207168854-aea54df7-0293-41b0-bea0-3f49fc2904c0.png">


## ✨ *Expected behavior:*

The link of the course [SVG Essentials & Animation, v2](https://frontendmasters.com/courses/svg-essentials-animation/?utm_source=stateofcss&utm_medium=website&utm_campaign=stateofcss2021&utm_content=textlink) by Sarah Drasner is redirecting to the Frontend Masters course.
