### PR TITLE
prevent creation of scrollbar for new people sociallinks

### DIFF
--- a/results/src/core/charts/people/PeopleBlock.tsx
+++ b/results/src/core/charts/people/PeopleBlock.tsx
@@ -411,7 +411,7 @@ const Links_ = styled.div`
     display: flex;
     justify-content: flex-start;
     @media ${mq.small} {
-        overflow-x: auto;
+        overflow-x: visible;
         width: 100%;
     }
 `


### PR DESCRIPTION
The new social links don't need to be constrained even at 320px wide but they do have a 1px miscalculation (?) scroll at smaller widths. So to prevent scrollbars appearing, just let them overflow that 1px.