### PR TITLE
First stab at `order` property to replace `randomize`, closes #293

### DIFF
--- a/api/src/graphql/typedefs/schema.graphql
+++ b/api/src/graphql/typedefs/schema.graphql
@@ -139,6 +139,7 @@ type QuestionMetadata {
     allowMultiple: Boolean
     countsTowardScore: Boolean
     randomize: Boolean
+    order: OptionsOrder
     cutoff: Int
     matchTags: [String]
     limit: Int
@@ -234,6 +235,12 @@ enum SortProperty {
 enum SortOrder {
     asc
     desc
+}
+
+enum OptionsOrder {
+    specified
+    random
+    alpha
 }
 
 type ResponseEditionData {

--- a/shared/fetch/queries/edition_metadata.ts
+++ b/shared/fetch/queries/edition_metadata.ts
@@ -95,6 +95,7 @@ export const getEditionMetadataQuery = ({ editionId }: { editionId: string }) =>
               countsTowardScore
               cutoff
               randomize
+              order
               optionsAreNumeric
               # optionsAreRange
               entity {

--- a/shared/types/outlines.ts
+++ b/shared/types/outlines.ts
@@ -140,6 +140,12 @@ export type ApiQuestion = {
     template?: string
 }
 
+export enum OptionsOrder {
+    SPECIFIED = "specified",
+    RANDOM = "random",
+    ALPHA = "alpha"
+}
+
 /**
  * Keep in sync with QuestionMetadata in
  * api/src/graphql/typedefs/schema.graphql
@@ -198,6 +204,7 @@ export type Question = {
     allowComment?: boolean
     showCommentInput?: boolean
     randomize?: boolean
+    order?: OptionsOrder
     /**
      * Question is used to compute the knowledge score
      */

--- a/surveyform/src/components/inputs/Checkboxgroup.tsx
+++ b/surveyform/src/components/inputs/Checkboxgroup.tsx
@@ -47,7 +47,7 @@ export const FormComponentCheckboxGroup = (
   // keep track of whether "other" field is shown or not
   const [showOther, setShowOther] = useState(!!otherValue);
 
-  const { options: options_, allowOther, limit, randomize } = question;
+  const { options: options_, allowOther, limit, randomize, order } = question;
 
   if (!options_) {
     throw new Error(
@@ -64,9 +64,23 @@ export const FormComponentCheckboxGroup = (
   options = options.filter((option) => option.id !== OPTION_NA);
 
   // either randomize or sort by alphabetical order
-  options = randomize
+  if (order) {
+    // Newer order option
+    if (order === "random") {
+      options = seededShuffle(options, response?._id || "outline");
+    }
+    else if (order === "alpha") {
+      options = sortBy(options, (option) => option.id);
+    }
+    // else use specified order
+  }
+  else {
+    // Deprecated randomize option
+    options = randomize
     ? seededShuffle(options, response?._id || "outline")
     : sortBy(options, (option) => option.id);
+  }
+
 
   const cutoff = question.cutoff || defaultCutoff;
 

--- a/surveyform/src/components/inputs/CheckboxgroupSentiment.tsx
+++ b/surveyform/src/components/inputs/CheckboxgroupSentiment.tsx
@@ -47,7 +47,7 @@ export const FormComponentCheckboxGroup = (
   // keep track of whether "other" field is shown or not
   const [showOther, setShowOther] = useState(!!otherValue);
 
-  const { options: options_, allowOther, limit, randomize } = question;
+  const { options: options_, allowOther, limit, randomize, order } = question;
 
   if (!options_) {
     throw new Error(
@@ -64,9 +64,22 @@ export const FormComponentCheckboxGroup = (
   options = options.filter((option) => option.id !== OPTION_NA);
 
   // either randomize or sort by alphabetical order
-  options = randomize
+  if (order) {
+    // Newer order option
+    if (order === "random") {
+      options = seededShuffle(options, response?._id || "outline");
+    }
+    else if (order === "alpha") {
+      options = sortBy(options, (option) => option.id);
+    }
+    // else use specified order
+  }
+  else {
+    // Deprecated randomize option
+    options = randomize
     ? seededShuffle(options, response?._id || "outline")
     : sortBy(options, (option) => option.id);
+  }
 
   const cutoff = question.cutoff || defaultCutoff;
 


### PR DESCRIPTION
Haven't tested it yet, wanted to get some feedback on direction.

Note that right now it will default to the old behavior if no `order` is set, for backwards compat. Eventually we probably want the default behavior to be the specified order; I cannot think of many use cases where alphabetical sorting is actually desirable (perhaps only demographics questions like Sector etc).

Not sure if `order` is too general; maybe we want to call it `optionsOrder`? 